### PR TITLE
Nest composite Composite inside RenderedPath

### DIFF
--- a/Sources/GraphicsTesting/GraphicsTesting.swift
+++ b/Sources/GraphicsTesting/GraphicsTesting.swift
@@ -40,7 +40,7 @@ public func openArtifactsDirectory() {
 }
 
 /// If running on macOS, create a PDF with the given `Composite` graphical object.
-public func render(_ composite: Composite, testName: String, fileName: String) {
+public func render(_ composite: RenderedPath.Composite, testName: String, fileName: String) {
     #if os(OSX)
     let layer = CALayer(composite)
     layer.renderToPDF(at: testCaseDirectory(for: testName).appendingPathComponent("fileName"))

--- a/Sources/QuartzAdapter/StyledPath.Composite+CALayer.swift
+++ b/Sources/QuartzAdapter/StyledPath.Composite+CALayer.swift
@@ -13,9 +13,9 @@ import Rendering
 
 extension CALayer {
 
-    public convenience init(_ composite: Composite) {
+    public convenience init(_ composite: RenderedPath.Composite) {
 
-        func traverse(_ composite: Composite, building container: CALayer) {
+        func traverse(_ composite: RenderedPath.Composite, building container: CALayer) {
             switch composite {
 
             // FIXME: Encapsulate in Item

--- a/Sources/Rendering/Composite.swift
+++ b/Sources/Rendering/Composite.swift
@@ -9,7 +9,11 @@
 import DataStructures
 import Geometry
 
-public typealias Composite = Tree<Group,Item>
+extension RenderedPath {
+
+    /// A hiearchical collection of rendered path graphical items.
+    public typealias Composite = Tree<Group,Item>
+}
 
 // TODO: Use extension RenderedPath.Composite when Swift allows it.
 extension Tree where Branch == Group, Leaf == Item {
@@ -23,7 +27,7 @@ extension Tree where Branch == Group, Leaf == Item {
         }
     }
 
-    public var resizedToFitContents: Composite {
+    public var resizedToFitContents: RenderedPath.Composite {
 
         switch self {
 
@@ -57,7 +61,7 @@ extension Tree where Branch == Group, Leaf == Item {
         }
     }
 
-    public func translated(by point: Point) -> Composite {
+    public func translated(by point: Point) -> RenderedPath.Composite {
         switch self {
         case let .leaf(renderedPath):
             return .leaf(renderedPath.translated(by: point))

--- a/Sources/Rendering/Renderable.swift
+++ b/Sources/Rendering/Renderable.swift
@@ -10,5 +10,5 @@
 public protocol Renderable {
     
     /// `Composite`-representation of `Renderable`-conforming type.
-    var rendered: Composite { get }
+    var rendered: RenderedPath.Composite { get }
 }

--- a/Sources/SVG/StyledPath.Composite+SVG.swift
+++ b/Sources/SVG/StyledPath.Composite+SVG.swift
@@ -27,7 +27,7 @@ extension Tree where Branch == Group, Leaf == Item {
     public init(_ svg: SVG) {
         
         // Transform SVG structure in RenderedPath.Composite
-        let structure: Composite = .init(svg.structure)
+        let structure: RenderedPath.Composite = .init(svg.structure)
 
         // Normalize frame
         // TODO: Move this all to RenderedPath.Composite.init
@@ -56,7 +56,7 @@ extension Tree where Branch == Group, Leaf == Item {
     public init(_ svg: SVG, height: Double) {
 
         // Transform SVG structure in RenderedPath.Composite
-        let structure: Composite = .init(svg.structure)
+        let structure: RenderedPath.Composite = .init(svg.structure)
 
         // Normalize frame
         // TODO: Move this all to RenderedPath.Composite.init
@@ -95,7 +95,7 @@ extension Tree where Branch == Group, Leaf == Item {
     public init(_ svg: SVG, width: Double) {
 
         // Transform SVG structure in RenderedPath.Composite
-        let structure: Composite = .init(svg.structure)
+        let structure: RenderedPath.Composite = .init(svg.structure)
 
         // Normalize frame
         // TODO: Move this all to RenderedPath.Composite.init


### PR DESCRIPTION
`Composite` has been a top-level `typealias`, but only because Swift did not allow some combination of (nested,generic) typealiases at the time of initial implementation.

This now give some context to what a `Composite` would be.