### PR TITLE
Improve APIs, add BezierCurve tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
 
         // Tests
         .testTarget(name: "GeometryTests", dependencies: ["Geometry"]),
-        .testTarget(name: "PathTests", dependencies: ["Path"]),
+        .testTarget(name: "PathTests", dependencies: ["Path", "Rendering", "GraphicsTesting"]),
         .testTarget(name: "RenderingTests", dependencies: ["Rendering", "GraphicsTesting"]),
         .testTarget(name: "SVGTests", dependencies: ["SVG", "GraphicsTesting"]),
         .testTarget(name: "QuartzAdapterTests", dependencies: ["QuartzAdapter", "GraphicsTesting"])

--- a/Sources/Path/BezierCurve.swift
+++ b/Sources/Path/BezierCurve.swift
@@ -151,7 +151,7 @@ public struct BezierCurve {
             let c = start
             let b = 2 * (points[1] - start)
             let a = start - 2 * points[1] + end
-            return quadratic(a.x, b.x, c.x)
+            return quadratic(a, b, c, \.x)
         case .cubic:
             return cardano(points: points, line: .vertical(at: x))
         }
@@ -166,7 +166,7 @@ public struct BezierCurve {
             let c = start
             let b = 2 * (points[1] - start)
             let a = start - 2 * points[1] + end
-            return quadratic(a.y, b.y, c.y)
+            return quadratic(a, b, c, \.y)
         case .cubic:
             return cardano(points: points, line: .horizontal(at: y))
         }
@@ -269,6 +269,10 @@ extension BezierCurve {
 }
 
 extension BezierCurve: Equatable { }
+
+public func quadratic(_ a: Point, _ b: Point, _ c: Point, _ keyPath: KeyPath<Point,Double>) -> Set<Double> {
+    return quadratic(a[keyPath: keyPath], a[keyPath: keyPath], a[keyPath: keyPath])
+}
 
 /// - returns: A `Set` of 0, 1, or 2 x-intercepts for the given coefficients.
 ///

--- a/Sources/Path/BezierCurve.swift
+++ b/Sources/Path/BezierCurve.swift
@@ -148,9 +148,10 @@ public struct BezierCurve {
         case .linear:
             return [(x - start.x) * (end.x - start.x)]
         case .quadratic:
+            let control = points[1]
             let c = start
-            let b = 2 * (points[1] - start)
-            let a = start - 2 * points[1] + end
+            let b = 2 * (control - start)
+            let a = start - 2 * control + end
             return quadratic(a, b, c, \.x)
         case .cubic:
             return cardano(points: points, line: .vertical(at: x))
@@ -163,9 +164,10 @@ public struct BezierCurve {
         case .linear:
             return [(y - start.y) * (end.y - start.y)]
         case .quadratic:
+            let control = points[1]
             let c = start
-            let b = 2 * (points[1] - start)
-            let a = start - 2 * points[1] + end
+            let b = 2 * (control - start)
+            let a = start - 2 * control + end
             return quadratic(a, b, c, \.y)
         case .cubic:
             return cardano(points: points, line: .horizontal(at: y))
@@ -270,7 +272,18 @@ extension BezierCurve {
 
 extension BezierCurve: Equatable { }
 
-public func quadratic(_ a: Point, _ b: Point, _ c: Point, _ keyPath: KeyPath<Point,Double>) -> Set<Double> {
+extension BezierCurve {
+    /// - Returns: Coefficients for quadratic ONLY!
+    private var coeffs: (Point,Point,Point) {
+        let control = points[1]
+        let c = start
+        let b = 2 * (control - start)
+        let a = start - 2 * control + end
+        return (a,b,c)
+    }
+}
+
+private func quadratic(_ a: Point, _ b: Point, _ c: Point, _ keyPath: KeyPath<Point,Double>) -> Set<Double> {
     return quadratic(a[keyPath: keyPath], a[keyPath: keyPath], a[keyPath: keyPath])
 }
 
@@ -403,3 +416,4 @@ extension Array {
     }
 
 }
+

--- a/Sources/Path/CubicBezierCurve.swift
+++ b/Sources/Path/CubicBezierCurve.swift
@@ -1,0 +1,87 @@
+//
+//  CubicBezierCurve.swift
+//  Path
+//
+//  Created by James Bean on 8/16/18.
+//
+
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin.C
+#endif
+
+import Geometry
+
+/// - TODO: Move somewhere meaningful, perhaps in a `Constant` enum.
+let tau: Double = 2 * .pi
+
+/// - TODO: Move somewhere meaningful.
+func cubeRoot(_ value: Double) -> Double {
+    return value > 0 ? pow(value, 1/3) : -pow(-value, 1/3)
+}
+
+/// - Returns: The `t` values intersecting where the given `curve` intersects the given line.
+///
+/// - Author: Pomax
+/// - See: http://jsbin.com/payifoxeho/edit?html,css,js
+/// - Note: Cardano's algorithm, based on
+/// http://www.trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm.
+///
+///
+/// - TODO: Use `Line` instead of `Line.Segment`.
+///
+func cardano(points: [Point], line: Line.Segment) -> Set<Double> {
+
+    func align(points: [Point], with line: Line.Segment) -> [Point] {
+        let a = -atan2(line.end.y - line.start.y, line.end.x - line.start.x)
+        return points.map { point in
+            Point(
+                x: (point.x - line.start.x) * cos(a) - (point.y - line.start.y) * sin(a),
+                y: (point.x - line.start.x) * sin(a) + (point.y - line.start.y) * cos(a)
+            )
+        }
+    }
+
+    let aligned = align(points: points, with: line)
+
+    let pa = aligned[0].y
+    let pb = aligned[1].y
+    let pc = aligned[2].y
+    let pd = aligned[3].y
+
+    let d = (-pa + 3 * pb - 3 * pc + pd)
+    let c = pa / d
+    let b = (-3 * pa + 3 * pb) / d
+    let a = (3 * pa - 6 * pb + 3 * pc) / d
+
+    let p = (3 * b - a * a) / 3
+    let p3 = p / 3
+    let q = (2 * pow(a,3) - 9 * a * b + 27 * c) / 27
+    let q2 = q / 2
+    let discriminant = pow(q2, 2) + pow(p3, 3)
+
+    if discriminant < 0 {
+        let mp3 = -p / 3
+        let mp33 = pow(mp3,3)
+        let r = sqrt(mp33)
+        let t = -q / (2 * r)
+        let cosphi = t < -1 ? -1 : t > 1 ? 1 : t
+        let phi = acos(cosphi)
+        let t1 = 2 * cubeRoot(r)
+        let x1 = t1 * cos(phi / 3) - a / 3
+        let x2 = t1 * cos((phi + tau) / 3) - a / 3
+        let x3 = t1 * cos((phi + 2 * tau) / 3) - a / 3
+        return [x1, x2, x3]
+    } else if discriminant == 0 {
+        let u1 = q2 < 0 ? cubeRoot(-q2) : -cubeRoot(q2)
+        let x1 = 2 * u1 - a / 3
+        let x2 = -u1 - a / 3
+        return [x1, x2]
+    } else {
+        let sd = sqrt(discriminant)
+        let x1 = cubeRoot(-q2 + sd) - cubeRoot(q2 + sd) - a / 3
+        return [x1]
+    }
+}
+

--- a/Sources/Path/Path.swift
+++ b/Sources/Path/Path.swift
@@ -36,6 +36,11 @@ public struct Path {
     public let curves: [BezierCurve]
     
     // MARK: - Initializers
+
+    /// Create a `Path` with a single `curve`.
+    public init(_ curve: BezierCurve) {
+        self.init([curve])
+    }
     
     /// Create a `Path` with the given `curves`.
     public init(_ curves: [BezierCurve]) {

--- a/Sources/Path/QuadraticBezierCurve.swift
+++ b/Sources/Path/QuadraticBezierCurve.swift
@@ -1,0 +1,45 @@
+//
+//  QuadraticBezierCurve.swift
+//  Path
+//
+//  Created by James Bean on 8/16/18.
+//
+
+#if os(Linux)
+import Glibc
+#else
+import Darwin.C
+#endif
+
+import Geometry
+
+/// - Returns: A `Set` of 0, 1, or 2 x-intercepts for the given coefficients.
+///
+/// - TODO: Update in dn-m/Math
+func quadratic(_ a: Double, _ b: Double, _ c: Double) -> Set<Double> {
+
+    print("quadratic: \(a), \(b), \(c)")
+    let discriminant = pow(b,2) - (4 * a * c)
+
+    guard discriminant >= 0 else {
+        return Set()
+    }
+
+    let val0 = (-b + sqrt(discriminant)) / (2 * a)
+    let val1 = (-b - sqrt(discriminant)) / (2 * a)
+
+    print("val0: \(val0), val1: \(val1)")
+
+    var result: Set<Double> = []
+
+    // This differs from the more generic version. Find a way to do this cleansing after?
+    if val0 <= 1 {
+        result.insert(val0)
+    }
+
+    if (0...1).contains(val1) {
+        result.insert(val1)
+    }
+
+    return result
+}

--- a/Sources/Rendering/Fill.swift
+++ b/Sources/Rendering/Fill.swift
@@ -28,8 +28,8 @@ public struct Fill {
     // MARK: - Initializers
     
     /// Creates a `Fill` with the given `color` and `rule`.
-    public init(color: Color = .black, rule: Rule = .nonZero) {
-        self.color = color
+    public init(color: Color? = nil, rule: Rule = .nonZero) {
+        self.color = color ?? Color(white: 1, alpha: 0)
         self.rule = rule
     }
 }

--- a/Sources/Rendering/Stroke.swift
+++ b/Sources/Rendering/Stroke.swift
@@ -52,15 +52,15 @@ public struct Stroke {
     
     /// Creates a `Stroke` with the given `width`, `color`, `join`, `cap`, and `dashes`.
     public init(
-        width: Double = 0,
-        color: Color = .black,
+        width: Double = 1,
+        color: Color? = nil,
         join: Join = .miter(limit: 10),
         cap: Cap = .butt,
         dashes: Dashes? = nil
     )
     {
         self.width = width
-        self.color = color
+        self.color = color ?? Color(white: 1, alpha: 0)
         self.join = join
         self.cap = cap
         self.dashes = dashes

--- a/Tests/PathTests/CubicBezierCurveTests.swift
+++ b/Tests/PathTests/CubicBezierCurveTests.swift
@@ -170,6 +170,36 @@ class CubicBezierCurveTests: XCTestCase {
         ])
         render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
+
+    func testBoundingBoxRender() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 24, y: 82),
+            control1: Point(x: 40, y: 90),
+            control2: Point(x: 90, y: 9),
+            end: Point(x: 100, y: 100)
+        )
+        let curvePath = Path(curve)
+        let styledCurve = StyledPath(
+            frame: frame,
+            path: curvePath,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+        let box = curve.axisAlignedBoundingBox
+        let boxPath = Path.rectangle(box)
+        let styledBox = StyledPath(
+            frame: frame,
+            path: boxPath,
+            styling: Styling(stroke: Stroke(color: .red))
+        )
+
+        let composite: StyledPath.Composite = .branch(group, [
+            .leaf(.path(styledBox)),
+            .leaf(.path(styledCurve))
+        ])
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
 }
 
 /// - TODO: Move to `dn-m/ArithmeticTools`.

--- a/Tests/PathTests/CubicBezierCurveTests.swift
+++ b/Tests/PathTests/CubicBezierCurveTests.swift
@@ -258,6 +258,39 @@ class CubicBezierCurveTests: XCTestCase {
         ])
         render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
+
+    func testScaledRender() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 40, y: 40),
+            control1: Point(x: 0, y: 60),
+            control2: Point(x: 60, y: 0),
+            end: Point(x: 60, y: 60)
+        )
+        let curvePath = Path(curve)
+        let styledCurve = StyledPath(
+            frame: frame,
+            path: curvePath,
+            styling: Styling(stroke: Stroke(color: .lightGray))
+        )
+        let referencePoint = Point(x: 25, y: 50)
+        let scaled = curve.scaled(by: 2, from: referencePoint)
+        let scaledPath = Path(scaled)
+        let styledScaled = StyledPath(
+            frame: frame,
+            path: scaledPath,
+            styling: Styling(stroke: Stroke(color: .red))
+        )
+        let dot = Path.circle(center: referencePoint, radius: 2)
+        let styledDot = StyledPath(path: dot, styling: Styling(fill: Fill(color: .red)))
+        let composite: StyledPath.Composite = .branch(group, [
+            .leaf(.path(styledCurve)),
+            .leaf(.path(styledScaled)),
+            .leaf(.path(styledDot))
+        ])
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
 }
 
 /// - TODO: Move to `dn-m/ArithmeticTools`.

--- a/Tests/PathTests/CubicBezierCurveTests.swift
+++ b/Tests/PathTests/CubicBezierCurveTests.swift
@@ -230,6 +230,34 @@ class CubicBezierCurveTests: XCTestCase {
         ])
         render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
+
+    func testSimplifiedRender() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 0),
+            control1: Point(x: 0, y: 100),
+            control2: Point(x: 100, y: 0),
+            end: Point(x: 100, y: 100)
+        )
+        let curvePath = Path(curve)
+        let styledCurve = StyledPath(
+            frame: frame,
+            path: curvePath,
+            styling: Styling(stroke: Stroke(width: 0.25, color: .lightGray))
+        )
+        let simplifiedPath = Polyline(curve.simplified(segmentCount: 10)).path
+        let styledSimplified = StyledPath(
+            frame: frame,
+            path: simplifiedPath,
+            styling: Styling(stroke: Stroke(width: 0.25, color: .red))
+        )
+        let composite: StyledPath.Composite = .branch(group, [
+            .leaf(.path(styledCurve)),
+            .leaf(.path(styledSimplified))
+        ])
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
 }
 
 /// - TODO: Move to `dn-m/ArithmeticTools`.

--- a/Tests/PathTests/CubicBezierCurveTests.swift
+++ b/Tests/PathTests/CubicBezierCurveTests.swift
@@ -200,6 +200,36 @@ class CubicBezierCurveTests: XCTestCase {
         ])
         render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
+
+    func testTranslatedByRender() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 0),
+            control1: Point(x: 0, y: 50),
+            control2: Point(x: 50, y: 0),
+            end: Point(x: 50, y: 50)
+        )
+        let translated = curve.translatedBy(x: 25, y: 25)
+        let curvePath = Path(curve)
+        let styledCurve = StyledPath(
+            frame: frame,
+            path: curvePath,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+
+        let translatedPath = Path(translated)
+        let styledTranslated = StyledPath(
+            frame: frame,
+            path: translatedPath,
+            styling: Styling(stroke: Stroke(color: .red))
+        )
+        let composite: StyledPath.Composite = .branch(group, [
+            .leaf(.path(styledCurve)),
+            .leaf(.path(styledTranslated))
+        ])
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
 }
 
 /// - TODO: Move to `dn-m/ArithmeticTools`.

--- a/Tests/PathTests/CubicBezierCurveTests.swift
+++ b/Tests/PathTests/CubicBezierCurveTests.swift
@@ -291,6 +291,39 @@ class CubicBezierCurveTests: XCTestCase {
         ])
         render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
+
+    func testRotatedRender() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 40, y: 40),
+            control1: Point(x: 0, y: 60),
+            control2: Point(x: 60, y: 0),
+            end: Point(x: 60, y: 60)
+        )
+        let curvePath = Path(curve)
+        let styledCurve = StyledPath(
+            frame: frame,
+            path: curvePath,
+            styling: Styling(stroke: Stroke(color: .lightGray))
+        )
+        let referencePoint = Point(x: 25, y: 50)
+        let rotated = curve.rotated(by: Angle(degrees: 270), around: referencePoint)
+        let rotatedPath = Path(rotated)
+        let styledRotated = StyledPath(
+            frame: frame,
+            path: rotatedPath,
+            styling: Styling(stroke: Stroke(color: .red))
+        )
+        let dot = Path.circle(center: referencePoint, radius: 2)
+        let styledDot = StyledPath(path: dot, styling: Styling(fill: Fill(color: .red)))
+        let composite: StyledPath.Composite = .branch(group, [
+            .leaf(.path(styledCurve)),
+            .leaf(.path(styledRotated)),
+            .leaf(.path(styledDot))
+        ])
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
 }
 
 /// - TODO: Move to `dn-m/ArithmeticTools`.

--- a/Tests/PathTests/CubicBezierCurveTests.swift
+++ b/Tests/PathTests/CubicBezierCurveTests.swift
@@ -8,9 +8,19 @@
 
 import XCTest
 import Geometry
+import Rendering
+import GraphicsTesting
 @testable import Path
 
 class CubicBezierCurveTests: XCTestCase {
+
+    override func setUp() {
+        createArtifactsDirectory(for: "\(type(of: self))")
+    }
+
+    override func tearDown() {
+        openArtifactsDirectory()
+    }
     
     func testUpAndDown() {
 
@@ -127,6 +137,38 @@ class CubicBezierCurveTests: XCTestCase {
         
         let simple = upAndDown.simplified(segmentCount: 100)
         print(simple)
+    }
+
+    func testSplitRender() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 0),
+            control1: Point(x: 0, y: 100),
+            control2: Point(x: 100, y: 0),
+            end: Point(x: 100, y: 100)
+        )
+
+        let (a,b) = curve.split(t: 0.75)
+
+        let pathA = Path(a)
+        let styledPathA = StyledPath(
+            frame: frame,
+            path: pathA,
+            styling: Styling(stroke: Stroke(color: .red))
+        )
+
+        let pathB = Path(b)
+        let styledPathB = StyledPath(
+            frame: frame,
+            path: pathB,
+            styling: Styling(stroke: Stroke(color: .green))
+        )
+        let composite: StyledPath.Composite = .branch(group, [
+            .leaf(.path(styledPathA)),
+            .leaf(.path(styledPathB))
+        ])
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
 }
 

--- a/Tests/PathTests/QuadraticBezierCurveTests.swift
+++ b/Tests/PathTests/QuadraticBezierCurveTests.swift
@@ -110,8 +110,6 @@ class QuadraticBezierCurveTests: XCTestCase {
         render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
 
-
-
     func testBezierCurveXsAtY() {
         let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
         let group = Group(frame: frame)

--- a/Tests/PathTests/QuadraticBezierCurveTests.swift
+++ b/Tests/PathTests/QuadraticBezierCurveTests.swift
@@ -9,36 +9,137 @@
 import XCTest
 import Geometry
 import Path
+import Rendering
+import GraphicsTesting
 
 class QuadraticBezierCurveTests: XCTestCase {
-    
-    // MARK: - Quadratic
-    
-    func testYsAtX() {
-        let slopeDown = BezierCurve(
-            start: Point(x: 0, y: 1),
-            control: Point(x: 0, y: 0),
-            end: Point(x: 1, y: 0)
-        )
-        stride(from: Double(0), to: 1, by: 0.01).forEach { t in
-            let point = slopeDown[t]
-            let ys = slopeDown.ys(x: point.x)
-            XCTAssertEqual(ys.count, 1)
-            XCTAssertEqual(ys.first!, point.y, accuracy: 1e-6)
-        }
+
+    override func setUp() {
+        createArtifactsDirectory(for: "\(type(of: self))")
+    }
+
+    override func tearDown() {
+        openArtifactsDirectory()
     }
     
-    func testXsAtY() {
-        let slopeDown = BezierCurve(
-            start: Point(x: 0, y: 1),
-            control: Point(x: 0, y: 0),
-            end: Point(x: 1, y: 0)
+    // MARK: - Quadratic
+
+    func testBezierCurveTsAtX() {
+
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 0),
+            control: Point(x: 0, y: 100),
+            end: Point(x: 100, y: 100)
         )
-        stride(from: Double(0), to: 1, by: 0.01).forEach { t in
-            let point = slopeDown[t]
-            let xs = slopeDown.xs(y: point.y)
-            XCTAssertEqual(xs.count, 1)
-            XCTAssertEqual(xs.first!, point.x, accuracy: 1e-6)
+        let dots = stride(from: 0.0, through: 100, by: 10).map { x -> StyledPath.Composite in
+
+            let t = curve.ts(x: x).first ?? 0
+            let y = curve[t].y
+
+            // Add lines for each `y` value
+            let linePath = Path.line(from: Point(x: x, y: 0), to: Point(x: x, y: 100))
+            let styling = Styling(stroke: Stroke(width: 0.25, color: .lightGray))
+            let styledLinePath = StyledPath(frame: frame, path: linePath, styling: styling)
+
+            // Add dots at intersection
+            let dotPath = Path.circle(center: Point(x: x, y: y), radius: 2)
+            let styledDotPath = StyledPath(
+                frame: frame,
+                path: dotPath,
+                styling: Styling(fill: Fill(color: .red))
+            )
+
+            return .branch(Group(), [
+                .leaf(Item.path(styledLinePath)),
+                .leaf(Item.path(styledDotPath))
+            ])
         }
+
+        let path = Path(curve)
+        let styledPath = StyledPath(
+            frame: frame,
+            path: path,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+        let composite: StyledPath.Composite = .branch(group, [.leaf(.path(styledPath))] + dots)
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
+
+    func testBezierCurveTsAtY() {
+
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 0),
+            control: Point(x: 0, y: 100),
+            end: Point(x: 100, y: 100)
+        )
+        let dots = stride(from: 0.0, through: 100, by: 10).map { y -> StyledPath.Composite in
+
+            let t = curve.ts(y: y).first ?? 0
+            let x = curve[t].x
+
+            // Add lines for each `y` value
+            let linePath = Path.line(from: Point(x: 0, y: y), to: Point(x: 100, y: y))
+            let styling = Styling(stroke: Stroke(width: 0.25, color: .lightGray))
+            let styledLinePath = StyledPath(frame: frame, path: linePath, styling: styling)
+
+            // Add dots at intersection
+            let dotPath = Path.circle(center: Point(x: x, y: y), radius: 2)
+            let styledDotPath = StyledPath(
+                frame: frame,
+                path: dotPath,
+                styling: Styling(fill: Fill(color: .red))
+            )
+
+            return .branch(Group(), [
+                .leaf(Item.path(styledLinePath)),
+                .leaf(Item.path(styledDotPath))
+            ])
+        }
+
+        let path = Path(curve)
+        let styledPath = StyledPath(
+            frame: frame,
+            path: path,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+        let composite: StyledPath.Composite = .branch(group, [.leaf(.path(styledPath))] + dots)
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
+
+
+
+    func testBezierCurveXsAtY() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 0),
+            control: Point(x: 25, y: 75),
+            end: Point(x: 100, y: 100)
+        )
+        let dots = stride(from: 0.0, through: 100, by: 10).map { y -> StyledPath.Composite in
+            let xs = curve.xs(y: y)
+            print("y: \(y), xs: \(xs)")
+            let x = xs.first ?? 0
+            let dotPath = Path.circle(center: Point(x: x,y: y), radius: 2)
+            let styledDotPath = StyledPath(
+                frame: frame,
+                path: dotPath,
+                styling: Styling(fill: Fill(color: .red))
+            )
+            return .leaf(Item.path(styledDotPath))
+        }
+
+        let path = Path(curve)
+        let styledPath = StyledPath(
+            frame: frame,
+            path: path,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+        let composite: StyledPath.Composite = .branch(group, [.leaf(.path(styledPath))] + dots)
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
 }

--- a/Tests/PathTests/XCTestManifests.swift
+++ b/Tests/PathTests/XCTestManifests.swift
@@ -49,8 +49,9 @@ extension PathTests {
 
 extension QuadraticBezierCurveTests {
     static let __allTests = [
-        ("testXsAtY", testXsAtY),
-        ("testYsAtX", testYsAtX),
+        ("testBezierCurveTsAtX", testBezierCurveTsAtX),
+        ("testBezierCurveTsAtY", testBezierCurveTsAtY),
+        ("testBezierCurveXsAtY", testBezierCurveXsAtY),
     ]
 }
 

--- a/Tests/RenderingTests/CompositeTests.swift
+++ b/Tests/RenderingTests/CompositeTests.swift
@@ -195,4 +195,101 @@ class CompositeTests: XCTestCase {
         render(composite, fileName: "\(#function)_before", testCaseName: "\(type(of: self))")
         render(resized, fileName: "\(#function)_after", testCaseName: "\(type(of: self))")
     }
+
+    func testBezierCurveTopLeftBottomRightEaseInEaseOut() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 0),
+            control1: Point(x: 50, y: 0),
+            control2: Point(x: 50, y: 100),
+            end: Point(x: 100, y: 100)
+        )
+        let path = Path(curve)
+        let styledPath = StyledPath(
+            frame: frame,
+            path: path,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+        let composite: StyledPath.Composite = .branch(group, [.leaf(.path(styledPath))])
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
+
+    func testBezierCurveBottomLeftTopRightEaseInEaseOut() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 100),
+            control1: Point(x: 50, y: 100),
+            control2: Point(x: 50, y: 0),
+            end: Point(x: 100, y: 0)
+        )
+        let path = Path(curve)
+        let styledPath = StyledPath(
+            frame: frame,
+            path: path,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+        let composite: StyledPath.Composite = .branch(group, [.leaf(.path(styledPath))])
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
+
+    func testBezierCurveRedDotsLinearX() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 100),
+            control1: Point(x: 50, y: 100),
+            control2: Point(x: 50, y: 0),
+            end: Point(x: 100, y: 0)
+        )
+        let dots = stride(from: 0.0, through: 100, by: 10).map { x -> StyledPath.Composite in
+            let y = curve.ys(x: x).first!
+            let dotPath = Path.circle(center: Point(x: x,y: y), radius: 2)
+            let styledDotPath = StyledPath(
+                frame: frame,
+                path: dotPath,
+                styling: Styling(fill: Fill(color: .red))
+            )
+            return .leaf(Item.path(styledDotPath))
+        }
+
+        let path = Path(curve)
+        let styledPath = StyledPath(
+            frame: frame,
+            path: path,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+        let composite: StyledPath.Composite = .branch(group, [.leaf(.path(styledPath))] + dots)
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
+
+    func testBezierCurveRedDotsLinearT() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 100),
+            control1: Point(x: 50, y: 100),
+            control2: Point(x: 50, y: 0),
+            end: Point(x: 100, y: 0)
+        )
+        let dots = stride(from: 0.0, through: 1, by: 0.1).map { t -> StyledPath.Composite in
+            let dotPath = Path.circle(center: curve[t], radius: 2)
+            let styledDotPath = StyledPath(
+                frame: frame,
+                path: dotPath,
+                styling: Styling(fill: Fill(color: .red))
+            )
+            return .leaf(Item.path(styledDotPath))
+        }
+
+        let path = Path(curve)
+        let styledPath = StyledPath(
+            frame: frame,
+            path: path,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+        let composite: StyledPath.Composite = .branch(group, [.leaf(.path(styledPath))] + dots)
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
 }

--- a/Tests/RenderingTests/CompositeTests.swift
+++ b/Tests/RenderingTests/CompositeTests.swift
@@ -234,6 +234,35 @@ class CompositeTests: XCTestCase {
         render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
 
+    func testBezierCurveRedDotsLinearT() {
+        let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
+        let group = Group(frame: frame)
+        let curve = BezierCurve(
+            start: Point(x: 0, y: 100),
+            control1: Point(x: 50, y: 100),
+            control2: Point(x: 50, y: 0),
+            end: Point(x: 100, y: 0)
+        )
+        let dots = stride(from: 0.0, through: 1, by: 0.1).map { t -> StyledPath.Composite in
+            let dotPath = Path.circle(center: curve[t], radius: 2)
+            let styledDotPath = StyledPath(
+                frame: frame,
+                path: dotPath,
+                styling: Styling(fill: Fill(color: .red))
+            )
+            return .leaf(Item.path(styledDotPath))
+        }
+
+        let path = Path(curve)
+        let styledPath = StyledPath(
+            frame: frame,
+            path: path,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
+        let composite: StyledPath.Composite = .branch(group, [.leaf(.path(styledPath))] + dots)
+        render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
+    }
+
     func testBezierCurveRedDotsLinearX() {
         let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
         let group = Group(frame: frame)
@@ -264,7 +293,7 @@ class CompositeTests: XCTestCase {
         render(composite, fileName: "\(#function)", testCaseName: "\(type(of: self))")
     }
 
-    func testBezierCurveRedDotsLinearT() {
+    func testBezierCurveRedDotsLinearY() {
         let frame = Rectangle(x: 0, y: 0, width: 100, height: 100)
         let group = Group(frame: frame)
         let curve = BezierCurve(
@@ -273,8 +302,10 @@ class CompositeTests: XCTestCase {
             control2: Point(x: 50, y: 0),
             end: Point(x: 100, y: 0)
         )
-        let dots = stride(from: 0.0, through: 1, by: 0.1).map { t -> StyledPath.Composite in
-            let dotPath = Path.circle(center: curve[t], radius: 2)
+        let dots = stride(from: 0.0, through: 100, by: 10).map { y -> StyledPath.Composite in
+            let xs = curve.xs(y: y)
+            let x = xs.filter { (0...100).contains($0) }.first!
+            let dotPath = Path.circle(center: Point(x: x,y: y), radius: 2)
             let styledDotPath = StyledPath(
                 frame: frame,
                 path: dotPath,

--- a/Tests/RenderingTests/CompositeTests.swift
+++ b/Tests/RenderingTests/CompositeTests.swift
@@ -130,7 +130,6 @@ class CompositeTests: XCTestCase {
     }
 
     func testResizedToFitContentsLeafScaleAndTranslation() {
-
         let frame = Rectangle(x: 10, y: 10, width: 100, height: 100)
         let path = Path.rectangle(x: 5, y: 5, width: 10, height: 10)
         let renderedPath = StyledPath(frame: frame, path: path)

--- a/Tests/RenderingTests/CompositeTests.swift
+++ b/Tests/RenderingTests/CompositeTests.swift
@@ -29,7 +29,7 @@ class CompositeTests: XCTestCase {
     func testTranslateLeaf() {
         let frame = Rectangle(x: 10, y: 10, width: 100, height: 100)
         let path = Path.circle(center: Point(), radius: 10)
-        let styled = StyledPath(frame: frame, path: path)
+        let styled = StyledPath(frame: frame, path: path, styling: Styling(fill: Fill(color: .black)))
         let leaf = StyledPath.Composite.leaf(.path(styled))
         let translated = leaf.translated(by: Point(x: 10, y: 10))
         let expected = Rectangle(x: 20, y: 20, width: 100, height: 100)
@@ -40,7 +40,7 @@ class CompositeTests: XCTestCase {
         let frame = Rectangle(x: 10, y: 10, width: 100, height: 100)
         let group = Group(frame: frame)
         let path = Path.circle(center: Point(), radius: 10)
-        let styled = StyledPath(frame: frame, path: path)
+        let styled = StyledPath(frame: frame, path: path, styling: Styling(fill: Fill(color: .black)))
         let leaf = StyledPath.Composite.leaf(.path(styled))
         let branch = StyledPath.Composite.branch(group, [leaf])
         let translated = branch.translated(by: Point(x: 10, y: 10))
@@ -57,9 +57,10 @@ class CompositeTests: XCTestCase {
     }
 
     func testLeafAxisAlignedBoundingBoxNonZeroFrame() {
+        let frame = Rectangle(origin: Point(x: 10, y: 10))
         let path = Path.circle(center: Point(), radius: 10)
-        let renderedPath = StyledPath(frame: Rectangle(origin: Point(x: 10, y: 10)), path: path)
-        let composite = StyledPath.Composite.leaf(.path(renderedPath))
+        let styled = StyledPath(frame: frame, path: path, styling: Styling(fill: Fill(color: .black)))
+        let composite = StyledPath.Composite.leaf(.path(styled))
         let bbox = composite.axisAlignedBoundingBox
         let expected = Rectangle(x: -20, y: -20, width: 20, height: 20)
         XCTAssertEqual(bbox, expected)
@@ -69,11 +70,11 @@ class CompositeTests: XCTestCase {
 
         // bbox: (0,0),20,100
         let a = Path.rectangle(origin: Point(), size: Size(width: 100, height: 10))
-        let styledA = StyledPath(path: a)
+        let styledA = StyledPath(path: a, styling: Styling(stroke: Stroke(color: .black)))
 
         // bbox: (-15,-15),40,40
         let b = Path.circle(center: Point(x: 5, y: 5), radius: 20)
-        let styledB = StyledPath(path: b)
+        let styledB = StyledPath(path: b, styling: Styling(stroke: Stroke(color: .black)))
         let composite = StyledPath.Composite.branch(
             Group(), [
                 .leaf(.path(styledA)),
@@ -89,11 +90,11 @@ class CompositeTests: XCTestCase {
 
         // bbox: (0,0),20,100
         let a = Path.rectangle(origin: Point(), size: Size(width: 100, height: 10))
-        let styledA = StyledPath(path: a)
+        let styledA = StyledPath(path: a, styling: Styling(stroke: Stroke(color: .black)))
 
         // bbox: (-15,-15),40,40
         let b = Path.circle(center: Point(x: 5, y: 5), radius: 20)
-        let styledB = StyledPath(path: b)
+        let styledB = StyledPath(path: b, styling: Styling(fill: Fill(color: .black)))
 
         let group = Group(frame: Rectangle(origin: Point(x: 1, y: 1)))
         let composite = StyledPath.Composite.branch(
@@ -111,8 +112,9 @@ class CompositeTests: XCTestCase {
 
     func testResizedToFitContentsLeafNoChange() {
         let rect = Rectangle(width: 10, height: 10)
-        let renderedPath = StyledPath(frame: rect, path: Path.rectangle(rect))
-        let composite = StyledPath.Composite.leaf(.path(renderedPath))
+        let styling = Styling(fill: Fill(color: .black))
+        let styled = StyledPath(frame: rect, path: Path.rectangle(rect), styling: styling)
+        let composite = StyledPath.Composite.leaf(.path(styled))
         let resized = composite.resizedToFitContents
         XCTAssertEqual(resized.frame, rect)
         render(composite, fileName: "\(#function)_before", testCaseName: "\(type(of: self))")
@@ -121,7 +123,8 @@ class CompositeTests: XCTestCase {
 
     func testResizedToFitContentsLeafNoTranslation() {
         let rect = Rectangle(width: 10, height: 10)
-        let renderedPath = StyledPath(frame: .zero, path: Path.rectangle(rect))
+        let styling = Styling(stroke: Stroke(color: .black))
+        let renderedPath = StyledPath(frame: .zero, path: Path.rectangle(rect), styling: styling)
         let composite = StyledPath.Composite.leaf(.path(renderedPath))
         let resized = composite.resizedToFitContents
         XCTAssertEqual(resized.frame, rect)
@@ -132,8 +135,8 @@ class CompositeTests: XCTestCase {
     func testResizedToFitContentsLeafScaleAndTranslation() {
         let frame = Rectangle(x: 10, y: 10, width: 100, height: 100)
         let path = Path.rectangle(x: 5, y: 5, width: 10, height: 10)
-        let renderedPath = StyledPath(frame: frame, path: path)
-        let composite = StyledPath.Composite.leaf(.path(renderedPath))
+        let styled = StyledPath(frame: frame, path: path, styling: Styling(fill: Fill(color: .black)))
+        let composite = StyledPath.Composite.leaf(.path(styled))
         let resized = composite.resizedToFitContents
         let expected = Rectangle(x: 5, y: 5, width: 10, height: 10)
         XCTAssertEqual(resized.frame, expected)
@@ -149,13 +152,21 @@ class CompositeTests: XCTestCase {
         let a = Path.rectangle(x: 0, y: 0, width: 3, height: 3)
 
         // Offset by 20,20 in parent coordinates
-        let styledA = StyledPath(frame: Rectangle(x: 20, y: 20, width: 4, height: 4), path: a)
+        let styledA = StyledPath(
+            frame: Rectangle(x: 20, y: 20, width: 4, height: 4),
+            path: a,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
 
         // Offset by 5,5 in own coordinates
         let b = Path.rectangle(x: 5, y: 5, width: 5, height: 5)
 
         // Offset by 2,2 in parent coordinates
-        let styledB = StyledPath(frame: Rectangle(x: 2, y: 2, width: 10, height: 10), path: b)
+        let styledB = StyledPath(
+            frame: Rectangle(x: 2, y: 2, width: 10, height: 10),
+            path: b,
+            styling: Styling(fill: Fill(color: .black))
+        )
 
         let composite = StyledPath.Composite.branch(group, [
             .leaf(.path(styledA)),
@@ -176,13 +187,21 @@ class CompositeTests: XCTestCase {
         let a = Path.rectangle(x: 0, y: 0, width: 3, height: 3)
 
         // Offset by 0,0 in parent coordinates
-        let styledA = StyledPath(frame: Rectangle(x: 0, y: 0, width: 3, height: 3), path: a)
+        let styledA = StyledPath(
+            frame: Rectangle(x: 0, y: 0, width: 3, height: 3),
+            path: a,
+            styling: Styling(fill: Fill(color: .black))
+        )
 
         // Offset by 0,0 in own coordinates
         let b = Path.rectangle(x: 0, y: 0, width: 10, height: 10)
 
         // Offset by 20,20 in parent coordinates
-        let styledB = StyledPath(frame: Rectangle(x: 20, y: 20, width: 10, height: 10), path: b)
+        let styledB = StyledPath(
+            frame: Rectangle(x: 20, y: 20, width: 10, height: 10),
+            path: b,
+            styling: Styling(stroke: Stroke(color: .black))
+        )
 
         let composite = StyledPath.Composite.branch(group, [
             .leaf(.path(styledA)),

--- a/Tests/RenderingTests/XCTestManifests.swift
+++ b/Tests/RenderingTests/XCTestManifests.swift
@@ -18,6 +18,11 @@ extension ColorTests {
 
 extension CompositeTests {
     static let __allTests = [
+        ("testBezierCurveBottomLeftTopRightEaseInEaseOut", testBezierCurveBottomLeftTopRightEaseInEaseOut),
+        ("testBezierCurveRedDotsLinearT", testBezierCurveRedDotsLinearT),
+        ("testBezierCurveRedDotsLinearX", testBezierCurveRedDotsLinearX),
+        ("testBezierCurveRedDotsLinearY", testBezierCurveRedDotsLinearY),
+        ("testBezierCurveTopLeftBottomRightEaseInEaseOut", testBezierCurveTopLeftBottomRightEaseInEaseOut),
         ("testBranchAllZeroFramedLeaves", testBranchAllZeroFramedLeaves),
         ("testBranchAllZeroFramedLeavesButNonZeroGroup", testBranchAllZeroFramedLeavesButNonZeroGroup),
         ("testLeafAxisAlignedBoundingBox", testLeafAxisAlignedBoundingBox),


### PR DESCRIPTION
This PR adds slight improvements to the `Path`, `Fill` and `Stroke` structures, as well as graphical tests for `BezierCurve` which show different ways of traversing it (either along `t` or `x` or `y`).