### PR TITLE
Add fill rule, line cap, and line join for new operating systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode9
+osx_image: xcode10
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:

--- a/Sources/QuartzAdapter/StyledPath+CAShapeLayer.swift
+++ b/Sources/QuartzAdapter/StyledPath+CAShapeLayer.swift
@@ -13,80 +13,62 @@ import Rendering
 
 extension CAShapeLayer {
     
-    public convenience init (_ renderedPath: StyledPath) {
-        
-        self.init(renderedPath.path)
-        frame = CGRect(renderedPath.frame)
-        let styling = renderedPath.styling
-        fillColor = styling.fill.color.cgColor
+    public convenience init (_ styledPath: StyledPath) {
+        self.init(styledPath.path)
+        let styling = styledPath.styling
+        self.fillColor = styling.fill.color.cgColor
+        self.strokeColor = styling.stroke.color.cgColor
+        self.lineDashPattern = styling.stroke.dashes?.pattern.map { NSNumber.init(value: $0) }
+        self.lineWidth = CGFloat(styling.stroke.width)
+        if let dashPhase = styling.stroke.dashes?.phase { self.lineDashPhase = CGFloat(dashPhase) }
+        if case .miter(let limit) = styling.stroke.join { self.miterLimit = CGFloat(limit) }
+        self.adaptProperties(from: styledPath)
+        self.frame = CGRect(styledPath.frame)
+    }
 
-        #warning("Add availability checking for fill and stroke conversions")
-//        if #available(macOS 10.14, *) {
-//            fillRule = styling.fill.rule.cgFillRule
-//            lineCap = styling.stroke.cap.cgCap
-//            lineJoin = styling.stroke.join.cgJoin
-//        }
+    /// Adapts the fill rule, line cap, and line join from the given `styledPath` for the Quartz
+    /// version supplied with the listed operating systems.
+    func adaptProperties(from styledPath: StyledPath) {
 
-        strokeColor = styling.stroke.color.cgColor
-        lineDashPattern = styling.stroke.dashes?.pattern.map { NSNumber.init(value: $0) }
-        lineWidth = CGFloat(styling.stroke.width)
-        
-        if let dashPhase = styling.stroke.dashes?.phase {
-            lineDashPhase = CGFloat(dashPhase)
-        }
-        
-        if case .miter(let limit) = styling.stroke.join {
-            miterLimit = CGFloat(limit)
+        if #available(macOS 10.14, iOS 12.0, tvOS 12.0, *) {
+            var cgFillRule: CAShapeLayerFillRule {
+                switch styledPath.styling.fill.rule {
+                case .nonZero:
+                    return .nonZero
+                case .evenOdd:
+                    return .evenOdd
+                }
+            }
+
+            var cgCap: CAShapeLayerLineCap {
+                switch styledPath.styling.stroke.cap {
+                case .butt:
+                    return .butt
+                case .round:
+                    return .round
+                case .square:
+                    return .square
+                }
+            }
+
+            var cgJoin: CAShapeLayerLineJoin {
+                switch styledPath.styling.stroke.join {
+                case .miter:
+                    return .miter
+                case .bevel:
+                    return .bevel
+                case .round:
+                    return .round
+                }
+            }
+
+            self.fillRule = cgFillRule
+            self.lineCap = cgCap
+            self.lineJoin = cgJoin
+        } else {
+            print("Fill.Rule is not avilable on your platform!")
         }
     }
 }
-
-#warning("Reintroduce Fill.Rule -> CAShapeLayerFillRule when available")
-//internal extension Fill.Rule {
-//
-//    @available(macOS 10.14, *)
-//    var cgFillRule: CAShapeLayerFillRule {
-//        switch self {
-//        case .nonZero:
-//            return .nonZero
-//        case .evenOdd:
-//            return .evenOdd
-//        }
-//    }
-//}
-//
-
-#warning("Reintroduce Stroke.Cap -> CAShapeLayerLineCap when available")
-//internal extension Stroke.Cap {
-//
-//    @available(macOS 10.14, *)
-//    var cgCap: CAShapeLayerLineCap {
-//        switch self {
-//        case .butt:
-//            return .butt
-//        case .round:
-//            return .round
-//        case .square:
-//            return .square
-//        }
-//    }
-//}
-//
-
-#warning("Reintroduce Stroke.Join -> CAShapeLayerLineJoin when available")
-//internal extension Stroke.Join {
-//
-//    @available(macOS 10.14, *)
-//    var cgJoin: CAShapeLayerLineJoin {
-//        switch self {
-//        case .miter:
-//            return .miter
-//        case .bevel:
-//            return .bevel
-//        case .round:
-//            return .round
-//        }
-//    }
-//}
 
 #endif


### PR DESCRIPTION
This PR adapts `StyledPath` values for the `CAShapeLayer*` types of the old and new APIs.