### PR TITLE
Workaround CollectionWrapping bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Graphics
 
-![Swift](https://img.shields.io/badge/Swift-4.2-brightgreen.svg)
+![Swift Version](https://img.shields.io/badge/Swift-5.0-orange.svg)
 [![Build Status](https://travis-ci.org/dn-m/Graphics.svg?branch=latest)](https://travis-ci.org/dn-m/Graphics)
 
 The `Graphics` package defines structures for graphically representing information, agnostic to the actual drawing API used.

--- a/Sources/Path/Path.swift
+++ b/Sources/Path/Path.swift
@@ -93,10 +93,34 @@ public struct Path {
     }
 }
 
-extension Path: CollectionWrapping {
+extension Path: Collection {
+
+    // MARK: - Collection
+
+    public typealias Base = [BezierCurve]
 
     public var base: [BezierCurve] {
         return curves
+    }
+
+    /// Start index.
+    public var startIndex: Base.Index {
+        return base.startIndex
+    }
+
+    /// End index.
+    public var endIndex: Base.Index {
+        return base.endIndex
+    }
+
+    /// Index after given index `i`.
+    public func index(after i: Base.Index) -> Base.Index {
+        return base.index(after: i)
+    }
+
+    /// - returns: Element at the given `index`.
+    public subscript (index: Base.Index) -> Base.Element {
+        return base[index]
     }
 }
 


### PR DESCRIPTION
This PR manually conforms `Path` to `Collection`, rather than using `CollectionWrapping`.